### PR TITLE
Fix child/parent class bug

### DIFF
--- a/lib/acts_as_unlockable/acts_as_unlocker.rb
+++ b/lib/acts_as_unlockable/acts_as_unlocker.rb
@@ -31,7 +31,7 @@ module Acts #:nodoc:
       raise UnlockLimitReached unless can_unlock?(unlockable)
       return false if has_unlocked?(unlockable)
 
-      self.unlocks.create!(:unlockable => unlockable)
+      self.unlocks.create!(:unlockable_id => unlockable.id, :unlockable_type => unlockable.class.name)
       return true
     end
     


### PR DESCRIPTION
When retreiving unlocks we use the child class name, but the creation will use the parent class, lets fix that